### PR TITLE
Refactor read_everything

### DIFF
--- a/tools/ES_plugin_script_ship_merging/ES_plugin_script_ship_merging.py
+++ b/tools/ES_plugin_script_ship_merging/ES_plugin_script_ship_merging.py
@@ -39,7 +39,8 @@ def read_everything(data_folder, folder_exclude):
 			if '#' in line:
 				pos1 = line.find('#')
 				line = line[:pos1].rstrip() + '\n'
-			elif line[:1] != '\t': # or line == lines[len(lines)-1]:
+
+			if line[:1] != '\t': # or line == lines[len(lines)-1]:
 				if started:
 					obj.append(txt.replace('<', '&#60;').replace('>', '&#62;'))
 					obj_path.append(txt2)


### PR DESCRIPTION
Made some changes to the read_everything function

Changes
- Create paths using os.path.join instead of string concatenation
- Get text files via os.walk() with ability to exclude directories from file search
- Simplified creation of padding variable
- Added more robust guard clauses for blank lines and comments
- Removed unused code
- Added missing deprecated ship, Quarg Skylark, to ship_exclude

Notes
- The order of the person ships in the output files is different, the files are otherwise the same

Performance impact
- New code executes in ~1.96 seconds consistently
- Old code executes in ~2.00 seconds on average, varies between 1.96 and 2.08 seconds