### PR TITLE
boss.loot: mismatched item name/image fix

### DIFF
--- a/myplugins/boss.loot/data/dun.conversation.1.txt
+++ b/myplugins/boss.loot/data/dun.conversation.1.txt
@@ -18,7 +18,7 @@
 # 2ndloot|25%|Voidstream Actuators (turn multiplier)|dun1_rare_outfit_5|outfit/dun1/dun1_device_05
 # 2ndloot|25%|Voidstream Replicator (acceleration multiplier)|dun1_rare_outfit_6|outfit/dun1/dun1_device_06
 # 2ndloot|25%|Voidstream Interdictors (thrust)|dun1_rare_outfit_7|outfit/dun1/dun1_device_07
-# 2ndloot|25%|Voidshell (resistance)|dun1_rare_outfit_8|outfit/dun1/dun1_device_08
+# 2ndloot|25%|Voidstream Shell (resistance)|dun1_rare_outfit_8|outfit/dun1/dun1_device_08
 conversation dun1_conversation_1
 	`You've defeated the enemy! While scanning the debris field you've found an unstable data drive with the code frequency for the next wormhole. It will probably break when you enter human space.`
 	`You've also found: `
@@ -134,8 +134,8 @@ conversation dun1_conversation_1
 	label "11"
 	action
 		outfit "dun1_rare_outfit_8" 1
-	`	Voidshell (resistance)`
-	scene "outfit/dun1/dun1_device_08"
+	`	Voidstream Shell (resistance)`
+	scene "outfit/dun1/dun1_device_12"
 	branch "end"
 	label "end"
 
@@ -414,7 +414,7 @@ conversation dun1_conversation_3
 # 2ndloot|8%|Voidstream Actuators (turn multiplier)|dun1_rare_outfit_5|outfit/dun1/dun1_device_05
 # 2ndloot|8%|Voidstream Replicator (acceleration multiplier)|dun1_rare_outfit_6|outfit/dun1/dun1_device_06
 # 2ndloot|8%|Voidstream Interdictors (thrust)|dun1_rare_outfit_7|outfit/dun1/dun1_device_07
-# 2ndloot|8%|Voidshell (resistance)|dun1_rare_outfit_8|outfit/dun1/dun1_device_08
+# 2ndloot|8%|Voidstream Shell (resistance)|dun1_rare_outfit_8|outfit/dun1/dun1_device_08
 # 2ndloot|8%|Dimensional Storage (cargo)|dun1_rare_outfit_9|outfit/dun1/dun1_device_09
 # 2ndloot|8%|Dimensional Refrigerator (cooling)|dun1_rare_outfit_10|outfit/dun1/dun1_device_10
 # 2ndloot|8%|Spa'ark Plug (energy)|dun1_rare_outfit_11|outfit/dun1/dun1_device_11
@@ -566,8 +566,8 @@ conversation dun1_conversation_4
 	label "11"
 	action
 		outfit "dun1_rare_outfit_8" 1
-	`	Voidshell (resistance)`
-	scene "outfit/dun1/dun1_device_08"
+	`	Voidstream Shell (resistance)`
+	scene "outfit/dun1/dun1_device_12"
 	branch "end"
 	label "12"
 	action
@@ -636,7 +636,7 @@ conversation dun1_conversation_4
 # 2ndloot|8%|Voidstream Actuators (turn multiplier)|dun1_rare_outfit_5|outfit/dun1/dun1_device_05
 # 2ndloot|8%|Voidstream Replicator (acceleration multiplier)|dun1_rare_outfit_6|outfit/dun1/dun1_device_06
 # 2ndloot|8%|Voidstream Interdictors (thrust)|dun1_rare_outfit_7|outfit/dun1/dun1_device_07
-# 2ndloot|8%|Voidshell (resistance)|dun1_rare_outfit_8|outfit/dun1/dun1_device_08
+# 2ndloot|8%|Voidstream Shell (resistance)|dun1_rare_outfit_8|outfit/dun1/dun1_device_08
 # 2ndloot|8%|Dimensional Storage (cargo)|dun1_rare_outfit_9|outfit/dun1/dun1_device_09
 # 2ndloot|8%|Dimensional Refrigerator (cooling)|dun1_rare_outfit_10|outfit/dun1/dun1_device_10
 # 2ndloot|8%|Spa'ark Plug (energy)|dun1_rare_outfit_11|outfit/dun1/dun1_device_11
@@ -788,8 +788,8 @@ conversation dun1_conversation_5
 	label "11"
 	action
 		outfit "dun1_rare_outfit_8" 1
-	`	Voidshell (resistance)`
-	scene "outfit/dun1/dun1_device_08"
+	`	Voidstream Shell (resistance)`
+	scene "outfit/dun1/dun1_device_12"
 	branch "end"
 	label "12"
 	action


### PR DESCRIPTION
As it says on the tin, the **_dun1_rare_outfit_8_** was named (and diff image) differently in the boss defeat conversation and the outfitter menu. Since the icon from the boss defeat conversation was already used for something, i changed it to the correct one (the outfitter one) along with the name (voidshell -> voidstream shell)